### PR TITLE
added BitSet::fromRawValue

### DIFF
--- a/bitset.c
+++ b/bitset.c
@@ -147,6 +147,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_bitset_fromstring, 0, 0, 1)
 	ZEND_ARG_INFO(0, str)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_bitset_fromrawvalue, 0, 0, 1)
+	ZEND_ARG_INFO(0, str)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_bitset_get, 0, 0, 1)
 	ZEND_ARG_INFO(0, index)
 ZEND_END_ARG_INFO()
@@ -425,6 +429,35 @@ PHP_METHOD(BitSet, getRawValue)
 	} else {
 		RETURN_EMPTY_STRING();
 	}
+}
+/* }}} */
+
+/* {{{ proto string BitSet::fromRawValue(void)
+ */
+PHP_METHOD(BitSet, fromRawValue)
+{
+	php_bitset_object *newobj;
+	zend_class_entry *ce = bitset_class_entry;
+	char *str = NULL;
+	int string_len = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &str, &string_len) == FAILURE) {
+		return;
+	}
+
+	newobj = php_bitset_objects_new(ce TSRMLS_CC);
+	return_value->type = IS_OBJECT;
+
+	if (string_len == 0) {
+		bitset_initialize_object(newobj, BITSET_DEFAULT_BITS TSRMLS_CC);
+		return_value->value.obj = php_bitset_register_object(newobj TSRMLS_CC);
+		return;
+	}
+
+	bitset_initialize_object(newobj, (string_len * CHAR_BIT) TSRMLS_CC);
+	memcpy(newobj->bitset_val, str, strlen(str));
+	
+	return_value->value.obj = php_bitset_register_object(newobj TSRMLS_CC);
 }
 /* }}} */
 
@@ -882,6 +915,7 @@ static const zend_function_entry bitset_class_method_entry[] = {
 	PHP_ME(BitSet, clear, arginfo_bitset_clear, ZEND_ACC_PUBLIC)
 	PHP_ME(BitSet, fromArray, arginfo_bitset_fromarray, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 	PHP_ME(BitSet, fromString, arginfo_bitset_fromstring, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+	PHP_ME(BitSet, fromRawValue, arginfo_bitset_fromrawvalue, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 	PHP_ME(BitSet, get, arginfo_bitset_get, ZEND_ACC_PUBLIC)
 	PHP_ME(BitSet, getRawValue, arginfo_bitset_getrawvalue, ZEND_ACC_PUBLIC)
 	PHP_ME(BitSet, intersects, arginfo_bitset_intersects, ZEND_ACC_PUBLIC)

--- a/tests/BitSet_fromRawValue.phpt
+++ b/tests/BitSet_fromRawValue.phpt
@@ -1,0 +1,17 @@
+--TEST--
+BitSet BitSet::fromRawValue() - Verifies the provided input raw value is represented in set bits
+--SKIPIF--
+<?php if (!extension_loaded('bitset')) die('skipping missing extension'); ?>
+--FILE--
+<?php
+$b = BitSet::fromRawValue(base64_decode('AA=='));
+var_dump($b->__toString());
+$b = BitSet::fromRawValue(base64_decode('IA=='));
+var_dump($b->__toString());
+var_dump(base64_encode($b->getRawValue()));
+?>
+--EXPECT--
+string(8) "00000000"
+string(8) "00000100"
+string(4) "IA=="
+


### PR DESCRIPTION
This is useful if you want to create a new instance of BitSet from a (stored) raw value you can get using BitSet::getFromValue, for example if you want to store a BitSet content for later usage in a memory efficient way to disk.