### PR TITLE
BitSet::set(0) should set the first bit only

### DIFF
--- a/bitset.c
+++ b/bitset.c
@@ -673,7 +673,7 @@ PHP_METHOD(BitSet, previousSetBit)
 PHP_METHOD(BitSet, set)
 {
 	php_bitset_object *intern;
-	long index_from = 0, index_to = 0, usable_index = 0;
+	long index_from = -1, index_to = 0, usable_index = 0;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|ll", &index_from, &index_to) == FAILURE) {
 		return;
@@ -681,15 +681,8 @@ PHP_METHOD(BitSet, set)
 
 	intern = bitset_get_intern_object(getThis() TSRMLS_CC);
 
-	/* Verify the start index is not greater than total bits */
-	if (index_from > (intern->bitset_len * CHAR_BIT - 1)) {
-		zend_throw_exception_ex(spl_ce_OutOfRangeException, 0 TSRMLS_CC,
-								"The requested start index is greater than the total number of bits");
-		return;
-	}
-
 	/* Set all bits */
-	if (index_from == 0 && index_to == 0) {
+	if (index_from == -1 && index_to == 0) {
 		for (; usable_index < intern->bitset_len * CHAR_BIT; usable_index++)
 		{
 			intern->bitset_val[usable_index / CHAR_BIT] |= (1 << (usable_index % CHAR_BIT));
@@ -697,6 +690,13 @@ PHP_METHOD(BitSet, set)
 
 		intern->bitset_val[intern->bitset_len] = '\0';
 	} else {
+		/* Verify the start index is not greater than total bits */
+		if (index_from > (intern->bitset_len * CHAR_BIT - 1)) {
+			zend_throw_exception_ex(spl_ce_OutOfRangeException, 0 TSRMLS_CC,
+									"The requested start index is greater than the total number of bits");
+			return;
+		}
+
 		if (index_to == 0) {
 			usable_index = index_from;
 		} else {

--- a/tests/BitSet_set.phpt
+++ b/tests/BitSet_set.phpt
@@ -12,6 +12,9 @@ var_dump($b->__toString());
 $b->set(2, 4);
 var_dump($b->__toString());
 
+$b->set(0);
+var_dump($b->__toString());
+
 $b->set(); // Set all bits on
 var_dump($b->__toString());
 ?>
@@ -19,5 +22,6 @@ var_dump($b->__toString());
 string(8) "00000000"
 string(8) "00100000"
 string(8) "00111000"
+string(8) "10111000"
 string(8) "11111111"
 


### PR DESCRIPTION
BitSet::set() is expected to set all bits in the bitset, however: BitSet::set(0) is imo expected to set only the first bit of the bitset. The latter is currently not the case.
