### PR TITLE
Off-by-one errors bugfix

### DIFF
--- a/bitset.c
+++ b/bitset.c
@@ -432,7 +432,7 @@ PHP_METHOD(BitSet, nextClearBit)
 	intern = bitset_get_intern_object(getThis());
 	bit_diff = intern->bitset_len * CHAR_BIT;
 
-	if (start_bit >= bit_diff) {
+	if (start_bit >= bit_diff - 1) {
 		zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0,
 								"There are no bits larger than the index provided");
 		return;

--- a/bitset.c
+++ b/bitset.c
@@ -537,7 +537,7 @@ PHP_METHOD(BitSet, previousClearBit)
 
 	if (start_bit < 1) {
 		zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0,
-								"There are no bits smaller than the index provided (zero)");
+								"There are no bits smaller than the index provided");
 		return;
 	}
 
@@ -550,7 +550,6 @@ PHP_METHOD(BitSet, previousClearBit)
 		return;
 	}
 
-	intern = bitset_get_intern_object(getThis());
 	start_bit--;
 
 	while (start_bit >= 0) {

--- a/bitset.c
+++ b/bitset.c
@@ -529,7 +529,7 @@ PHP_METHOD(BitSet, orOp)
 PHP_METHOD(BitSet, previousClearBit)
 {
 	php_bitset_object *intern;
-	long start_bit = 0;
+	long bit_diff = 0, start_bit = 0;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &start_bit) == FAILURE) {
 		return;
@@ -538,6 +538,15 @@ PHP_METHOD(BitSet, previousClearBit)
 	if (start_bit < 1) {
 		zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0,
 								"There are no bits smaller than the index provided (zero)");
+		return;
+	}
+
+	intern = bitset_get_intern_object(getThis());
+	bit_diff = intern->bitset_len * CHAR_BIT;
+
+	if (start_bit > bit_diff) {
+		zend_throw_exception_ex(spl_ce_OutOfRangeException, 0,
+								"The specified index parameter exceeds the total number of bits available");
 		return;
 	}
 

--- a/bitset.c
+++ b/bitset.c
@@ -302,7 +302,7 @@ PHP_METHOD(BitSet, get)
 	intern = bitset_get_intern_object(getThis());
 
 	/* The bit requested is larger than all bits in this set */
-	if (bit > intern->bitset_len * CHAR_BIT) {
+	if (bit >= intern->bitset_len * CHAR_BIT) {
 		zend_throw_exception_ex(spl_ce_OutOfRangeException, 0,
 								"The specified index parameter exceeds the total number of bits available");
 		return;

--- a/bitset.c
+++ b/bitset.c
@@ -474,7 +474,7 @@ PHP_METHOD(BitSet, nextSetBit)
 	intern = bitset_get_intern_object(getThis());
 	bit_diff = intern->bitset_len * CHAR_BIT;
 
-	if (start_bit >= bit_diff) {
+	if (start_bit >= bit_diff - 1) {
 		zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0,
 								"There are no bits larger than the index provided");
 		return;

--- a/bitset.c
+++ b/bitset.c
@@ -575,6 +575,7 @@ PHP_METHOD(BitSet, previousSetBit)
 {
 	php_bitset_object *intern;
 	zend_long start_bit = 0;
+        long bit_diff = 0;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &start_bit) == FAILURE) {
 		return;
@@ -582,11 +583,19 @@ PHP_METHOD(BitSet, previousSetBit)
 
 	if (start_bit < 1) {
 		zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0,
-								"There are no bits smaller than the index provided (zero)");
+								"There are no bits smaller than the index provided");
 		return;
 	}
 
 	intern = bitset_get_intern_object(getThis());
+	bit_diff = intern->bitset_len * CHAR_BIT;
+
+	if (start_bit > bit_diff) {
+		zend_throw_exception_ex(spl_ce_OutOfRangeException, 0,
+								"The specified index parameter exceeds the total number of bits available");
+		return;
+	}
+
 	start_bit--;
 
 	while (start_bit >= 0) {

--- a/bitset.c
+++ b/bitset.c
@@ -269,7 +269,7 @@ PHP_METHOD(BitSet, clear)
 		intern->bitset_val[intern->bitset_len] = '\0';
 	} else {
 		/* Verify the start index is not greater than total bits */
-		if (index_from > intern->bitset_len * CHAR_BIT) {
+		if (index_from >= intern->bitset_len * CHAR_BIT) {
 			zend_throw_exception_ex(spl_ce_OutOfRangeException, 0,
 									"The requested start index is greater than the total number of bits");
 			return;

--- a/tests/BitSet_clear.phpt
+++ b/tests/BitSet_clear.phpt
@@ -22,6 +22,11 @@ var_dump($b->__toString());
 $b->set(0, 1);
 $b->clear(0);
 var_dump($b->__toString());
+try {
+    var_dump($b->clear(64));
+} catch (Exception $e) {
+    echo get_class($e).': '.$e->getMessage()."\n";
+}
 ?>
 --EXPECT--
 bool(true)
@@ -29,3 +34,4 @@ bool(false)
 string(64) "0000000000000000000000000000000000000000000000000000000000000000"
 string(64) "0000000000000000000010000000000000000000000000000000000000000000"
 string(64) "0100000000000000000010000000000000000000000000000000000000000000"
+OutOfRangeException: The requested start index is greater than the total number of bits

--- a/tests/BitSet_get.phpt
+++ b/tests/BitSet_get.phpt
@@ -6,13 +6,20 @@ BitSet BitSet::get() - Verifies integrity of bit index retrieval
 <?php
 $b = new BitSet(); // 64 bits is fine
 $b->set(5);
+var_dump($b->get(0));
 var_dump($b->get(5));
 var_dump($b->get(20));
 $b->set(20);
 var_dump($b->get(20));
+try {
+    var_dump($b->get(64));
+} catch (Exception $e) {
+    echo get_class($e).'-'.$e->getMessage()."\n";
+}
 ?>
 --EXPECT--
+bool(false)
 bool(true)
 bool(false)
 bool(true)
-
+OutOfRangeException-The specified index parameter exceeds the total number of bits available

--- a/tests/BitSet_nextClearBit.phpt
+++ b/tests/BitSet_nextClearBit.phpt
@@ -7,12 +7,19 @@ BitSet BitSet::nextClearBit() - Verifies the next clear bit is valid based on th
 $b = new BitSet(); // 64 bits is fine
 $b->set(20);
 $b->set(18);
+var_dump($b->nextClearBit(0));
 var_dump($b->nextClearBit(20));
 var_dump($b->nextClearBit(18));
 var_dump($b->nextClearBit(5));
+try {
+    var_dump($b->nextClearBit(63));
+} catch (Exception $e) {
+    echo get_class($e).': '.$e->getMessage()."\n";
+}
 ?>
 --EXPECT--
+int(1)
 int(21)
 int(19)
 int(6)
-
+InvalidArgumentException: There are no bits larger than the index provided

--- a/tests/BitSet_nextSetBit.phpt
+++ b/tests/BitSet_nextSetBit.phpt
@@ -7,12 +7,20 @@ BitSet BitSet::nextSetBit() - Verifies the next set bit is valid based on the pr
 $b = new BitSet(); // 64 bits is fine
 $b->set(20);
 $b->set(18);
+var_dump($b->nextSetBit(0));
 var_dump($b->nextSetBit(20));
 var_dump($b->nextSetBit(18));
 var_dump($b->nextSetBit(5));
+try {
+    var_dump($b->nextSetBit(63));
+} catch (Exception $e) {
+    echo get_class($e).': '.$e->getMessage()."\n";
+}
+
 ?>
 --EXPECT--
+int(18)
 bool(false)
 int(20)
 int(18)
-
+InvalidArgumentException: There are no bits larger than the index provided

--- a/tests/BitSet_previousClearBit.phpt
+++ b/tests/BitSet_previousClearBit.phpt
@@ -7,6 +7,11 @@ BitSet BitSet::previousClearBit() - Verifies the previous clear bit is valid bas
 $b = new BitSet(); // 64 bits is fine
 $b->set(20);
 $b->set(18);
+try {
+    var_dump($b->previousClearBit(0));
+} catch (Exception $e) {
+    var_dump(get_class($e).': '.$e->getMessage());
+}
 var_dump($b->previousClearBit(20));
 var_dump($b->previousClearBit(18));
 var_dump($b->previousClearBit(5));
@@ -17,6 +22,7 @@ try {
 }
 ?>
 --EXPECT--
+string(75) "InvalidArgumentException: There are no bits smaller than the index provided"
 int(19)
 int(17)
 int(4)

--- a/tests/BitSet_previousClearBit.phpt
+++ b/tests/BitSet_previousClearBit.phpt
@@ -10,9 +10,14 @@ $b->set(18);
 var_dump($b->previousClearBit(20));
 var_dump($b->previousClearBit(18));
 var_dump($b->previousClearBit(5));
+try {
+    var_dump($b->previousClearBit(65));
+} catch (Exception $e) {
+    var_dump(get_class($e).': '.$e->getMessage());
+}
 ?>
 --EXPECT--
 int(19)
 int(17)
 int(4)
-
+string(93) "OutOfRangeException: The specified index parameter exceeds the total number of bits available"

--- a/tests/BitSet_previousSetBit.phpt
+++ b/tests/BitSet_previousSetBit.phpt
@@ -7,13 +7,25 @@ BitSet BitSet::previousSetBit() - Verifies the previous set bit is valid based o
 $b = new BitSet(); // 64 bits is fine
 $b->set(20);
 $b->set(18);
+try {
+    var_dump($b->previousSetBit(0));
+} catch (Exception $e) {
+    var_dump(get_class($e).': '.$e->getMessage());
+}
 var_dump($b->previousSetBit(20));
 var_dump($b->previousSetBit(18));
 $b->set(1);
 var_dump($b->previousSetBit(5));
+try {
+    var_dump($b->previousSetBit(65));
+} catch (Exception $e) {
+    var_dump(get_class($e).': '.$e->getMessage());
+}
 ?>
 --EXPECT--
+string(75) "InvalidArgumentException: There are no bits smaller than the index provided"
 int(18)
 bool(false)
 int(1)
+string(93) "OutOfRangeException: The specified index parameter exceeds the total number of bits available"
 

--- a/tests/BitSet_set.phpt
+++ b/tests/BitSet_set.phpt
@@ -15,13 +15,23 @@ var_dump($b->__toString());
 $b->set(0);
 var_dump($b->__toString());
 
+$b->set(7);
+var_dump($b->__toString());
+
 $b->set(); // Set all bits on
 var_dump($b->__toString());
+
+try {
+    var_dump($b->set(8));
+} catch (Exception $e) {
+    var_dump(get_class($e).': '.$e->getMessage());
+}
 ?>
 --EXPECT--
 string(8) "00000000"
 string(8) "00100000"
 string(8) "00111000"
 string(8) "10111000"
+string(8) "10111001"
 string(8) "11111111"
-
+string(87) "OutOfRangeException: The requested start index is greater than the total number of bits"


### PR DESCRIPTION
Several BitSet methods show off-by-one errors on the last bit (example : `$b->clear(64)` should throw an exception when it currently passes).

This PR fix off-by-one errors or adds tests for this on following methods: `get`, `set`, `clear`, `nextClearBit`, `nextSetBit`, `previousClearBit`, `previousSetBit`.
