### PR TITLE
Fix #63315: BitSet::fromArray may modify original array value

### DIFF
--- a/bitset.c
+++ b/bitset.c
@@ -728,16 +728,11 @@ PHP_METHOD(BitSet, fromArray)
 	bitset_initialize_object(newobj, highest_value);
 
 	ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(bit_array), entry) {
-		ZVAL_DEREF(entry);
-        SEPARATE_ZVAL_NOREF(entry);
+		zend_long entry_long = zval_get_long(entry);
 
-		if (Z_TYPE_P(entry) != IS_LONG) {
-			convert_to_long(entry);
-		}
-
-		if (Z_LVAL_P(entry) > 0) {
-			entry_actual = Z_LVAL_P(entry) / CHAR_BIT;
-			newobj->bitset_val[entry_actual] |= (1 << (Z_LVAL_P(entry) % CHAR_BIT));
+		if (entry_long > 0) {
+			entry_actual = entry_long / CHAR_BIT;
+			newobj->bitset_val[entry_actual] |= (1 << (entry_long % CHAR_BIT));
 		}
 	} ZEND_HASH_FOREACH_END();
 
@@ -864,15 +859,10 @@ static long bitset_get_highest_value_from_array(zval *arr)
 	long highest_value = 0;
 
 	ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(arr), entry) {
-		ZVAL_DEREF(entry);
-        SEPARATE_ZVAL_NOREF(entry);
-		
-		if (Z_TYPE_P(entry) != IS_LONG) {
-			convert_to_long_ex(entry);
-		}
+		zend_long entry_long = zval_get_long(entry);
 
-		if (Z_LVAL_P(entry) > highest_value) {
-			highest_value = Z_LVAL_P(entry);
+		if (entry_long > highest_value) {
+			highest_value = entry_long;
 		}
 	} ZEND_HASH_FOREACH_END();
 

--- a/tests/bug63315.phpt
+++ b/tests/bug63315.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Bug #63315 (BitSet::fromArray may modify original array value)
+--SKIPIF--
+<?php if (!extension_loaded('bitset')) die('skipping missing extension'); ?>
+--FILE--
+<?php
+$arr = array(5, 6, '7');
+var_dump($arr);
+BitSet::fromArray($arr);
+var_dump($arr);
+?>
+--EXPECT--
+array(3) {
+  [0]=>
+  int(5)
+  [1]=>
+  int(6)
+  [2]=>
+  string(1) "7"
+}
+array(3) {
+  [0]=>
+  int(5)
+  [1]=>
+  int(6)
+  [2]=>
+  string(1) "7"
+}


### PR DESCRIPTION
We could prevent that modification by separating the array via ZPP, but
actually there is no need for converting the zval to long; instead we
use `zval_get_long()` what already caters to references.  We also drop
the now useless separation.